### PR TITLE
Order Note By Last Edit Time

### DIFF
--- a/src/app/services/note.service.ts
+++ b/src/app/services/note.service.ts
@@ -32,8 +32,8 @@ export class NoteService {
     return this.http.get(url, { headers })
       .map((response: Response) => {
         this.status = response.status;
+        this.notes = Object.values(response.json().notes);
 
-        this.notes = Object.values(response.json().notes).reverse();
         return this.notes;
       })
       .catch((response: Response) => {
@@ -128,7 +128,7 @@ export class NoteService {
   }
 
   /**
-   * It updates the in memory notes. This is important so that user won't have to reload the page to update the dom
+   * It updates the in-memory notes. This is important so that user won't have to reload the page to update the dom
    *
    * @param {Response} response http response
    *


### PR DESCRIPTION
The backend now return notes based based on in the order by which they were last updated. Reversing the fetched notes is no longer necessary.
