### PR TITLE
add ability to remove a tag from a note

### DIFF
--- a/src/app/components/note-editor/note-editor.component.html
+++ b/src/app/components/note-editor/note-editor.component.html
@@ -6,14 +6,14 @@
       <div class="tags-container">
         <div>
           <span class="tag" *ngFor="let tag of note.tags; trackBy: trackTagsById">{{tag.name}}
-            <button>x</button>
+            <button (click)=removeTag($event)>x</button>
           </span>
         </div>
         <span class="add-tag">
           <ul class="dropup-items" *ngIf="foundTags?.length > 0">
             <li *ngFor="let tag of foundTags">{{tag}}</li>
           </ul>
-          <form (ngSubmit)="addTag()">
+          <form autocomplete="off" (ngSubmit)="addTag()">
             <input #tagInput (focusin)="createTagSearchListener($event)" *ngIf="isTagInputOpen" type="text" maxlength="70" [(ngModel)]="tag" name="tag" autofocus />
             <input type="button" [value]="this.tagging ? 'x' : '+'" class="add" (click)="toggleTagInput()">
           </form>

--- a/src/app/components/note-editor/note-editor.component.ts
+++ b/src/app/components/note-editor/note-editor.component.ts
@@ -146,12 +146,12 @@ export class NoteEditorComponent implements OnChanges {
   createTagSearchListener(event: FocusEvent) {
     event.preventDefault();
 
-     this.tagSearchListener =  fromEvent(this.tagInput.nativeElement, 'keyup')
-        .debounceTime(500)
-        .distinctUntilChanged()
-        .subscribe(
-          (evt: KeyboardEvent) => this.performTagSearch(evt, this.tag)
-        );
+    this.tagSearchListener = fromEvent(this.tagInput.nativeElement, 'keyup')
+      .debounceTime(500)
+      .distinctUntilChanged()
+      .subscribe(
+        (evt: KeyboardEvent) => this.performTagSearch(evt, this.tag)
+      );
   }
 
   /**
@@ -176,6 +176,26 @@ export class NoteEditorComponent implements OnChanges {
         );
     }
   }
+
+  /**
+   * It removes a tag from note's tags list0
+   *
+   * @param {MouseEvent} event click event
+   */
+  removeTag(event: { target: HTMLElement }) {
+    const tag = event.target
+      .parentElement
+      .childNodes[0]
+      .nodeValue;
+    const foundTag = this.tagService.findTagByName(this.note.tags, tag);
+
+    this.tagService.removeTagFromNote(this.note.id, foundTag.id)
+      .subscribe(
+        (updatedTags) => { this.note.tags = updatedTags; },
+        message => this.status = message
+      );
+  }
+
 
   /**
    * Submit edited note.

--- a/src/app/models/index.ts
+++ b/src/app/models/index.ts
@@ -1,2 +1,3 @@
 export { User } from './user.interface';
 export { Note } from './note.interface';
+export { Tag } from './tag.interface';

--- a/src/app/models/note.interface.ts
+++ b/src/app/models/note.interface.ts
@@ -1,6 +1,8 @@
+import { Tag } from './tag.interface';
+
 export interface Note {
   id?: number;
   title: string;
   content: string;
-  tags?: string[];
+  tags?: Tag[];
 }

--- a/src/app/models/tag.interface.ts
+++ b/src/app/models/tag.interface.ts
@@ -1,0 +1,4 @@
+export interface Tag {
+    id?: number;
+    name: string;
+}

--- a/src/app/services/tag.service.ts
+++ b/src/app/services/tag.service.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs/Rx';
 
 
 import { apiBaseUrl } from '../../env';
+import { Tag } from '../models';
 
 @Injectable()
 export class TagService {
@@ -34,6 +35,20 @@ export class TagService {
     tagNote(tag: string, noteId: number): Observable<string[] | string> {
         return this.http
             .put(`${apiBaseUrl}/notes/tags/${noteId}`, { tag })
+            .map((response: any) => response.tags)
+            .catch(this.handleError.bind(this));
+    }
+
+    /**
+     * It removes a tag from a note
+     *
+     * @param noteId Id of the note to be deleted
+     * @param tagId  Id of the tag to be deleted
+     *
+     * @return {Observable<any>}
+     */
+    removeTagFromNote(noteId: number, tagId: number): Observable<any> {
+        return this.http.delete(`${apiBaseUrl}/notes/${noteId}/tags/${tagId}`)
             .map((response: any) => response.tags)
             .catch(this.handleError.bind(this));
     }
@@ -73,6 +88,18 @@ export class TagService {
         }
 
         return Observable.throw(response.json().message);
+    }
+
+    /**
+     * It finds a tag by it's name from an array of tags
+     *
+     * @param {Tag[]} tags an array of tags to search from
+     * @param {string} tagToFind tag name to find
+     *
+     * @return {Tag}
+     */
+    findTagByName(tags: Tag[], tagToFind: string): Tag {
+        return tags.find(tag => tag.name.trim() === tagToFind.trim());
     }
 
     /**


### PR DESCRIPTION
#### What this pr does.

This pr implements the ability to delete a tag from a note.
a method findTagByName was written to help find the tag whose delete button was
clicked. Then the id is used to delete the tag from the backend

#### how to manually test this.
Assuming your [backend](https://github.com/ngfizzy/ps-note-taker) is started, click on a note that has a tag, then click on the `x` button on a tag to remove one of the tags